### PR TITLE
Fixed issue where SVG original click/focus not being sent to SVG element

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -250,7 +250,7 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		return (/\bneedsclick\b/).test(target.getAttribute('class'));
 	};
 
 
@@ -280,7 +280,7 @@
 			// No point in attempting to focus disabled inputs
 			return !target.disabled && !target.readOnly;
 		default:
-			return (/\bneedsfocus\b/).test(target.className);
+			return (/\bneedsfocus\b/).test(target.getAttribute('class'));
 		}
 	};
 

--- a/tests/svg-needsclick.html
+++ b/tests/svg-needsclick.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <script type="application/javascript" src="../lib/fastclick.js"></script>
+    <title>Needsclick Not working on SVGs - target.className is an SVG Animated String</title>
+    <script type="application/javascript">
+        var circleClick = function(e) {
+            var isTrue  = '<span style="color: green">True</span>';
+            var isFalse = '<span style="color: red">False</span>';
+            document.querySelector('h1').innerHTML = 'Needs Click Working = ' +
+                    (e.forwardedTouchEvent ? isFalse : isTrue);
+        };
+        window.addEventListener('load', function() {
+            FastClick.attach(document.body);
+
+            var svgCircle = document.querySelector('.svg-circle');
+            svgCircle.addEventListener('click', circleClick);
+        }, false);
+    </script>
+</head>
+<body>
+    <div>
+        <h1>Needs Click Working = Unknown</h1>
+        <svg height="400" width="400" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="200" cy="100" r="50" fill="#000000" stroke="#000000" class="svg-circle needsclick"></circle>
+            <text x="200" y="200" font-size="25" style="text-anchor: middle">Click Circle</text>
+            <text x="200" y="225" font-size="20" style="text-anchor: middle" onclick="window.location.reload();">Reset</text>
+        </svg>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
- SVG Elements are SVGAnimatedString's and cannot retrieve className in the same way as HTML elements.
- Used getAttribute('class'), as this converts the baseVal/animVal to the appropriate string representation.
